### PR TITLE
disable compare

### DIFF
--- a/NetPing_modern/Content/JavaScript/ProductItem.js
+++ b/NetPing_modern/Content/JavaScript/ProductItem.js
@@ -3,4 +3,15 @@
         $(this).addClass('active').parent().find('.active').not(this).removeClass('active');
         $('.tab-c[data-tab-id=' + $(this).data('tab-id') + ']').addClass('shown').parent().find('.shown').not('.tab-c[data-tab-id=' + $(this).data('tab-id') + ']').removeClass('shown');
     });
+
+    checkCompare();
+
+    $('input[type=checkbox][name=compare]').on('click', checkCompare);
 });
+
+function checkCompare() {
+    if ($('input[type=checkbox][name=compare]:checked').length < 2)
+        $('.btn.compare').attr('disabled', 'disabled');
+    else
+        $('.btn.compare').removeAttr('disabled');
+}

--- a/NetPing_modern/Views/Products/Adaptive_Index.cshtml
+++ b/NetPing_modern/Views/Products/Adaptive_Index.cshtml
@@ -295,7 +295,7 @@
                                 </div>
                                 <div class="col-xs-6 col-lg-12 compare text-right button-block">
                                     <input type="checkbox" id="check-@device.Id" name="compare" value="@device.Id" /><label for="check-@device.Id" class="checkbox"></label>
-                                    <button class="btn btn-default">Сравнить</button>
+                                    <button class="btn btn-default compare">Сравнить</button>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
[bug] На новых страницах каталога устройств если количество чек-боксов
"Сравнить устройства" установлено менее двух, кнопки "Сравнить" сделать
неактивными